### PR TITLE
Add generic query endpoint to active modules.

### DIFF
--- a/src/api/buildings/index.js
+++ b/src/api/buildings/index.js
@@ -3,11 +3,22 @@ import express from 'express'
 import list from './routes/list'
 import search from './routes/search'
 import show from './routes/show'
+import Building from './model'
 
+import { createGenericQueryParser } from '../../utils/genericQuery'
 import validator from '../../utils/validator'
 import { tokenValidator } from '../../utils/apiTokenManager'
 
 const router = express.Router()
+
+// TODO: docs for query endpoint
+router.get('/query',
+  tokenValidator,
+  validator.limit,
+  validator.offset,
+  validator.sort,
+  createGenericQueryParser(Building),
+)
 
 /* eslint-disable */
 /**

--- a/src/api/courses/index.js
+++ b/src/api/courses/index.js
@@ -3,11 +3,22 @@ import express from 'express'
 import list from './routes/list'
 import search from './routes/search'
 import show from './routes/show'
+import Course from './model'
 
+import { createGenericQueryParser } from '../../utils/genericQuery'
 import validator from '../../utils/validator'
 import { tokenValidator } from '../../utils/apiTokenManager'
 
 const router = express.Router()
+
+// TODO: docs for query endpoint
+router.get('/query',
+  tokenValidator,
+  validator.limit,
+  validator.offset,
+  validator.sort,
+  createGenericQueryParser(Course),
+)
 
 /* eslint-disable */
 /**

--- a/src/api/departments/index.js
+++ b/src/api/departments/index.js
@@ -3,11 +3,22 @@ import express from 'express'
 import list from './routes/list'
 import search from './routes/search'
 import show from './routes/show'
+import Department from './model'
 
+import { createGenericQueryParser } from '../../utils/genericQuery'
 import validator from '../../utils/validator'
 import { tokenValidator } from '../../utils/apiTokenManager'
 
 const router = express.Router()
+
+// TODO: docs for query endpoint
+router.get('/query',
+  tokenValidator,
+  validator.limit,
+  validator.offset,
+  validator.sort,
+  createGenericQueryParser(Department),
+)
 
 /**
  * @api {get} /departments/ List Departments

--- a/src/api/sections/index.js
+++ b/src/api/sections/index.js
@@ -3,11 +3,22 @@ import express from 'express'
 import list from './routes/list'
 import search from './routes/search'
 import show from './routes/show'
+import Section from './model'
 
+import { createGenericQueryParser } from '../../utils/genericQuery'
 import validator from '../../utils/validator'
 import { tokenValidator } from '../../utils/apiTokenManager'
 
 const router = express.Router()
+
+// TODO: docs for query endpoint
+router.get('/query',
+  tokenValidator,
+  validator.limit,
+  validator.offset,
+  validator.sort,
+  createGenericQueryParser(Section),
+)
 
 /* eslint-disable */
 /**

--- a/src/api/textbooks/index.js
+++ b/src/api/textbooks/index.js
@@ -3,12 +3,22 @@ import express from 'express'
 import list from './routes/list'
 import search from './routes/search'
 import show from './routes/show'
+import Textbook from './model'
 
+import { createGenericQueryParser } from '../../utils/genericQuery'
 import validator from '../../utils/validator'
 import { tokenValidator } from '../../utils/apiTokenManager'
 
 const router = express.Router()
 
+// TODO: docs for query endpoint
+router.get('/query',
+  tokenValidator,
+  validator.limit,
+  validator.offset,
+  validator.sort,
+  createGenericQueryParser(Textbook),
+)
 /**
  * @api {get} /textbooks List Textbooks
  * @apiName ListTextbooks

--- a/src/utils/genericQuery.js
+++ b/src/utils/genericQuery.js
@@ -1,0 +1,16 @@
+
+const createGenericQueryParser = (MongooseModel) => async (req, res, next) => {
+  const { limit, offset, sort, token, ...rest } = req.query
+  try {
+    const docs = await MongooseModel.find(rest, '-_id -__v')
+      .limit(req.query.limit)
+      .skip(req.query.offset)
+      .sort(req.query.sort)
+      .exec()
+    res.json(docs)
+  } catch (ex) {
+    return next(ex)
+  }
+}
+
+export { createGenericQueryParser }


### PR DESCRIPTION
/query endpoint works by using all (non-reserved keyword) query parameters and feeding them into the Mongoose model find. This should work for all top level string and number fields.

Examples of working queries:
https://qmulus-et-query-xcz7exumwcuede.herokuapp.com/v1/sections/query?department=CISC&course_code=124&token=b3a25130f86711e9bbd791d423055b1a
https://qmulus-et-query-xcz7exumwcuede.herokuapp.com/v1/buildings/query?campus=west&token=b3a25130f86711e9bbd791d423055b1a
https://qmulus-et-query-xcz7exumwcuede.herokuapp.com/v1/courses/query?department=CISC&token=b3a25130f86711e9bbd791d423055b1a
https://qmulus-et-query-xcz7exumwcuede.herokuapp.com/v1/textbooks/query?status=REQUIRED&token=b3a25130f86711e9bbd791d423055b1a